### PR TITLE
CloudFront Invalidation Path fixed /* to "/*"

### DIFF
--- a/.github/workflows/fedeploy.yaml
+++ b/.github/workflows/fedeploy.yaml
@@ -55,4 +55,4 @@ jobs:
           CLOUD_FRONT_ID: ${{ secrets.AWS_CLOUDFRONT_ID }} #cloudfront ID 
         run: |
           aws cloudfront create-invalidation \
-            --distribution-id $CLOUD_FRONT_ID --paths /*
+            --distribution-id $CLOUD_FRONT_ID --paths "/*"


### PR DESCRIPTION
배포는 잘 되는데 갱신하는 경로가 기본값으로 되어있어 변경사항이 보이지 않았던 이슈입니다. 경로 수정 처리 했습니다.